### PR TITLE
ci: GitHub Actions CI (lint/format/typecheck/test 並列実行)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,21 @@
+name: 'Setup'
+description: 'Checkout, install Node.js via mise, and install npm dependencies'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: jdx/mise-action@v2
+      with:
+        install_args: node
+
+    - name: Cache node_modules
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          node-modules-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: npm run lint
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: npm run format:check
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: npm run typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: npm run test


### PR DESCRIPTION
## Summary
- Composite Actionで共通セットアップ（checkout + mise + npm ci）をDRYに切り出し
- PR・mainプッシュ時にlint / format / typecheck / testを4ジョブ並列実行
- concurrency設定で同一ブランチの古い実行を自動キャンセル

## 追加ファイル
| ファイル | 役割 |
|---|---|
| `.github/actions/setup/action.yml` | Composite Action (checkout + mise + npm ci + キャッシュ) |
| `.github/workflows/ci.yml` | CIワークフロー (4ジョブ並列) |

## 手動作業（マージ後）
GitHub Settings → Rules → Rulesets で、mainブランチに対して以下のステータスチェックを必須に設定:
- Lint / Format / Typecheck / Test

## Test plan
- [ ] PRでCIワークフローが起動することを確認
- [ ] 4ジョブ（Lint, Format, Typecheck, Test）が並列実行されることを確認
- [ ] 全ジョブがグリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)