### PR TITLE
fix: 駅検索時のジオコーディング404エラーを修正

### DIFF
--- a/src/composables/useStationSearch/types.ts
+++ b/src/composables/useStationSearch/types.ts
@@ -4,4 +4,6 @@ export interface Station {
   address: string;
   distance?: number;
   placeId: string;
+  lat?: number;
+  lng?: number;
 }

--- a/src/programs/searchRestaurants.ts
+++ b/src/programs/searchRestaurants.ts
@@ -20,14 +20,22 @@ export const searchRestaurantsProgram = (
     const api = yield* ApiService;
     const { keywords, searchLocation, searchRadius } = params;
 
-    // 駅からジオコーディングして位置を取得
-    const geocoded = yield* api.geocodeForward(
-      `${searchLocation.name}駅,${searchLocation.prefecture}`,
-    );
+    // 座標が既にある場合はそのまま使用、なければジオコーディング
+    let location: { lat: number; lng: number };
+    if (searchLocation.lat != null && searchLocation.lng != null) {
+      location = { lat: searchLocation.lat, lng: searchLocation.lng };
+    } else {
+      const stationName = searchLocation.name.endsWith('駅')
+        ? searchLocation.name
+        : `${searchLocation.name}駅`;
+      location = yield* api.geocodeForward(
+        `${stationName},${searchLocation.prefecture}`,
+      );
+    }
 
     return yield* api.searchRestaurants({
       keywords,
-      location: { lat: geocoded.lat, lng: geocoded.lng },
+      location,
       radius: searchRadius,
       stationPlaceId: searchLocation.placeId,
     });

--- a/worker/src/lib/station-filter.test.ts
+++ b/worker/src/lib/station-filter.test.ts
@@ -10,8 +10,8 @@ describe('isStation', () => {
     expect(isStation(['subway_station', 'transit_station'])).toBe(true);
   });
 
-  it('returns true for transit_station', () => {
-    expect(isStation(['transit_station', 'point_of_interest'])).toBe(true);
+  it('returns false for transit_station only (e.g. bus terminal)', () => {
+    expect(isStation(['transit_station', 'point_of_interest'])).toBe(false);
   });
 
   it('returns false for non-station types', () => {

--- a/worker/src/lib/station-filter.ts
+++ b/worker/src/lib/station-filter.ts
@@ -1,4 +1,4 @@
-const STATION_TYPES = ['train_station', 'subway_station', 'transit_station'];
+const STATION_TYPES = ['train_station', 'subway_station'];
 
 /**
  * Check if a place type list includes a station type.

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -72,6 +72,8 @@ function placeToStation(
     address: place.vicinity ?? '',
     distance,
     placeId: place.place_id,
+    lat: place.geometry?.location.lat,
+    lng: place.geometry?.location.lng,
   };
 }
 

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -161,13 +161,14 @@ stationRoutes.post('/stations/nearby', async (c) => {
     places = cached;
   } else {
     // Search for train stations within 5km
+    // type を指定しないことで subway_station のみの駅も漏れなく取得し、
+    // isStation フィルタで train_station / subway_station に絞る
     const result = await searchNearbyPlaces(
       apiKey,
       lat,
       lng,
       5000,
       '駅',
-      'train_station',
     );
 
     if (!result.ok) {

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -163,13 +163,7 @@ stationRoutes.post('/stations/nearby', async (c) => {
     // Search for train stations within 5km
     // type を指定しないことで subway_station のみの駅も漏れなく取得し、
     // isStation フィルタで train_station / subway_station に絞る
-    const result = await searchNearbyPlaces(
-      apiKey,
-      lat,
-      lng,
-      5000,
-      '駅',
-    );
+    const result = await searchNearbyPlaces(apiKey, lat, lng, 5000, '駅');
 
     if (!result.ok) {
       return c.json({ success: false, error: result.error }, 500);

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -34,6 +34,8 @@ export interface Station {
   address: string;
   distance?: number;
   placeId: string;
+  lat?: number;
+  lng?: number;
 }
 
 // API Request types


### PR DESCRIPTION
nearby検索で取得済みの座標をStation型に保持し、ジオコーディングを
スキップすることで「田町駅駅」のような駅名二重化による404を解消。
autocomplete経由の場合も駅名末尾の「駅」重複を防止。

https://claude.ai/code/session_01UnZd4ABmgzC6k8gPzKHosK