### PR TITLE
fix: 駅名検索で「新宿駅」のように「駅」付きの入力でも結果が返るように修正

### DIFF
--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -127,9 +127,11 @@ stationRoutes.post('/stations/search', async (c) => {
     );
   }
 
-  const stations: Station[] = predictions
-    .filter((p) => isStation(p.types))
-    .map(predictionToStation);
+  // Autocomplete API にはリクエスト時に types=train_station|subway_station を
+  // 指定済みなので、レスポンスは既に駅に限定されている。
+  // ここで isStation フィルタをかけると、Google が types フィールドに
+  // transit_station のみを返したり undefined を返した場合に候補が消えてしまう。
+  const stations: Station[] = predictions.map(predictionToStation);
 
   return c.json({ success: true, data: stations });
 });

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -90,7 +90,10 @@ stationRoutes.post('/stations/search', async (c) => {
 
   const db = createDb(c.env.DB);
   const apiKey = c.env.GOOGLE_MAPS_API_KEY;
-  const input = body.input.trim();
+  // 末尾の「駅」を除去して正規化（「新宿駅」→「新宿」）
+  // Google Autocomplete API に types=train_station|subway_station と併用すると
+  // 「駅」付きの入力では結果が返らないことがあるため
+  const input = body.input.trim().replace(/駅$/, '');
 
   const cacheKey = input;
 


### PR DESCRIPTION
Google Maps Autocomplete APIにtypes=train_station|subway_stationフィルタと
「駅」付きのクエリを同時に送ると結果が返らない問題を修正。
入力から末尾の「駅」を除去してからAPIに送信するようにした。

https://claude.ai/code/session_01A92EbPYyjv8yAMf88DxcUW