### PR TITLE
fix: 駅検索で新宿駅等の主要駅が候補に表示されない問題を修正

### DIFF
--- a/.claude/plans/buzzing-wibbling-cocke.md
+++ b/.claude/plans/buzzing-wibbling-cocke.md
@@ -13,6 +13,7 @@ Google Places Autocomplete API は「予測補完」APIであり、「新宿」�
 ### 1. `worker/src/services/google-maps.ts` - Text Search 関数の追加
 
 新関数 `searchStationByText` を追加:
+
 - API: `/maps/api/place/textsearch/json`
 - パラメータ: `query="{input}駅"`, `type=train_station`, `language=ja`
 - 戻り値: `Result<GooglePlaceResult[]>`（既存型を再利用）
@@ -27,6 +28,7 @@ Google Places Autocomplete API は「予測補完」APIであり、「新宿」�
 Text Search API は `vicinity` の代わりに `formatted_address` を返すため。
 
 Text Search レスポンス型を追加:
+
 ```ts
 export interface GoogleTextSearchResponse {
   results: GooglePlaceResult[];
@@ -63,13 +65,13 @@ export interface GoogleTextSearchResponse {
 
 ## 修正ファイル一覧
 
-| ファイル | 変更内容 |
-|---|---|
-| `worker/src/types.ts` | `GooglePlaceResult` に `formatted_address?` 追加、`GoogleTextSearchResponse` 追加 |
-| `worker/src/services/cache.ts` | `station_text_search` TTL追加 |
-| `worker/src/services/google-maps.ts` | `searchStationByText` 関数追加、`types` 簡素化 |
-| `worker/src/routes/stations.ts` | マージロジック実装 |
-| `worker/src/lib/station-filter.ts` | `transit_station` を STATION_TYPES に追加 |
+| ファイル                             | 変更内容                                                                          |
+| ------------------------------------ | --------------------------------------------------------------------------------- |
+| `worker/src/types.ts`                | `GooglePlaceResult` に `formatted_address?` 追加、`GoogleTextSearchResponse` 追加 |
+| `worker/src/services/cache.ts`       | `station_text_search` TTL追加                                                     |
+| `worker/src/services/google-maps.ts` | `searchStationByText` 関数追加、`types` 簡素化                                    |
+| `worker/src/routes/stations.ts`      | マージロジック実装                                                                |
+| `worker/src/lib/station-filter.ts`   | `transit_station` を STATION_TYPES に追加                                         |
 
 ## 検証方法
 

--- a/.claude/plans/buzzing-wibbling-cocke.md
+++ b/.claude/plans/buzzing-wibbling-cocke.md
@@ -1,0 +1,82 @@
+# 駅検索で「新宿駅」が候補に表示されない問題の修正
+
+## Context
+
+ユーザーが「新宿」や「新宿駅」と入力しても、候補リストにメインの「新宿駅」が表示されない。
+Google Places Autocomplete API は「予測補完」APIであり、「新宿」に対してより具体的な駅名（新宿三丁目駅、新宿西口駅等）を優先的に返す。
+これは API の仕様上の挙動であり、パラメータ調整では根本解決できない。
+
+**修正方針**: Autocomplete 結果を Text Search API で補完し、入力に直接マッチする駅を確実に候補に含める。
+
+## 変更内容
+
+### 1. `worker/src/services/google-maps.ts` - Text Search 関数の追加
+
+新関数 `searchStationByText` を追加:
+- API: `/maps/api/place/textsearch/json`
+- パラメータ: `query="{input}駅"`, `type=train_station`, `language=ja`
+- 戻り値: `Result<GooglePlaceResult[]>`（既存型を再利用）
+- 既存の `searchNearbyPlaces` と同じエラーハンドリングパターンに従う
+
+また、`types` パラメータを `train_station|subway_station|transit_station` → `transit_station` に簡素化。
+（`transit_station` は `train_station`/`subway_station` の上位型。Legacy API ではパイプ区切り複数指定の挙動が不安定）
+
+### 2. `worker/src/types.ts` - 型の拡張
+
+`GooglePlaceResult` に `formatted_address?: string` を追加。
+Text Search API は `vicinity` の代わりに `formatted_address` を返すため。
+
+Text Search レスポンス型を追加:
+```ts
+export interface GoogleTextSearchResponse {
+  results: GooglePlaceResult[];
+  status: string;
+}
+```
+
+### 3. `worker/src/services/cache.ts` - キャッシュTTL追加
+
+`CACHE_TTL` に `station_text_search: 86400` (24h) を追加。
+
+### 4. `worker/src/routes/stations.ts` - マージロジック
+
+`POST /api/stations/search` ハンドラを修正:
+
+```
+入力: "新宿"（/駅$/ 除去は維持）
+
+1. D1キャッシュをそれぞれチェック
+2. キャッシュミス分のみ Promise.all で並列実行:
+   - Autocomplete API("新宿")
+   - Text Search API("新宿駅", type=train_station)
+3. 各結果をD1キャッシュに保存
+4. Text Search 結果を Station に変換（placeToStation 的な関数）
+5. place_id で重複除去し、Text Search の完全一致を先頭に配置
+6. 最大10件程度で返却
+```
+
+**エラーハンドリング**: Text Search が失敗しても Autocomplete 結果のみで応答（デグレードしない）
+
+### 5. `worker/src/lib/station-filter.ts` - transit_station 追加
+
+`STATION_TYPES` に `'transit_station'` を追加。nearby search のフィルタにも対応。
+
+## 修正ファイル一覧
+
+| ファイル | 変更内容 |
+|---|---|
+| `worker/src/types.ts` | `GooglePlaceResult` に `formatted_address?` 追加、`GoogleTextSearchResponse` 追加 |
+| `worker/src/services/cache.ts` | `station_text_search` TTL追加 |
+| `worker/src/services/google-maps.ts` | `searchStationByText` 関数追加、`types` 簡素化 |
+| `worker/src/routes/stations.ts` | マージロジック実装 |
+| `worker/src/lib/station-filter.ts` | `transit_station` を STATION_TYPES に追加 |
+
+## 検証方法
+
+1. `npm run typecheck` でビルドエラーがないことを確認
+2. Chrome DevTools MCP で実際に駅検索を実行:
+   - 「新宿」→ 候補に「新宿駅」が含まれること
+   - 「新宿駅」→ 候補に「新宿駅」が含まれること
+   - 「渋谷」→ 候補に「渋谷駅」が含まれること
+   - 既存の周辺駅（新宿三丁目駅等）も引き続き表示されること
+3. Worker の開発サーバーでAPIレスポンスを直接確認

--- a/worker/src/lib/station-filter.test.ts
+++ b/worker/src/lib/station-filter.test.ts
@@ -10,8 +10,8 @@ describe('isStation', () => {
     expect(isStation(['subway_station', 'transit_station'])).toBe(true);
   });
 
-  it('returns false for transit_station only (e.g. bus terminal)', () => {
-    expect(isStation(['transit_station', 'point_of_interest'])).toBe(false);
+  it('returns true for transit_station (covers major stations like 新宿駅)', () => {
+    expect(isStation(['transit_station', 'point_of_interest'])).toBe(true);
   });
 
   it('returns false for non-station types', () => {

--- a/worker/src/lib/station-filter.ts
+++ b/worker/src/lib/station-filter.ts
@@ -1,4 +1,4 @@
-const STATION_TYPES = ['train_station', 'subway_station'];
+const STATION_TYPES = ['train_station', 'subway_station', 'transit_station'];
 
 /**
  * Check if a place type list includes a station type.

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -67,8 +67,7 @@ function placeToStation(
     );
   }
 
-  const addressSource =
-    place.vicinity ?? place.formatted_address ?? '';
+  const addressSource = place.vicinity ?? place.formatted_address ?? '';
 
   return {
     name: place.name,
@@ -114,6 +113,7 @@ stationRoutes.post('/stations/search', async (c) => {
   );
 
   // Fetch uncached results in parallel
+  // oxlint-disable-next-line effect-enforce/no-promise-static-methods -- Worker側はEffectを使用していない
   const [predictionsResult, textSearchResult] = await Promise.all([
     cachedPredictions
       ? Promise.resolve(null)

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -4,6 +4,7 @@ import { getCache, setCache, CACHE_TTL } from '../services/cache';
 import {
   getAutocompletePredictions,
   searchNearbyPlaces,
+  searchStationByText,
 } from '../services/google-maps';
 import { haversineDistance } from '../lib/haversine';
 import { isStation } from '../lib/station-filter';
@@ -49,15 +50,15 @@ function predictionToStation(
 }
 
 /**
- * Convert a nearby place result to a Station.
+ * Convert a place result (Nearby Search or Text Search) to a Station.
  */
 function placeToStation(
   place: GooglePlaceResult,
-  searchLat: number,
-  searchLng: number,
+  searchLat?: number,
+  searchLng?: number,
 ): Station {
   let distance: number | undefined;
-  if (place.geometry?.location) {
+  if (searchLat != null && searchLng != null && place.geometry?.location) {
     distance = haversineDistance(
       searchLat,
       searchLng,
@@ -66,10 +67,13 @@ function placeToStation(
     );
   }
 
+  const addressSource =
+    place.vicinity ?? place.formatted_address ?? '';
+
   return {
     name: place.name,
-    prefecture: extractPrefecture(place.vicinity ?? ''),
-    address: place.vicinity ?? '',
+    prefecture: extractPrefecture(addressSource),
+    address: addressSource,
     distance,
     placeId: place.place_id,
     lat: place.geometry?.location.lat,
@@ -79,7 +83,8 @@ function placeToStation(
 
 /**
  * POST /api/stations/search
- * Search for stations by name using autocomplete.
+ * Search for stations by name using autocomplete, supplemented with
+ * Text Search to ensure exact station matches (e.g. "新宿駅") appear.
  */
 stationRoutes.post('/stations/search', async (c) => {
   const body = await c.req.json<StationSearchRequest>();
@@ -91,47 +96,84 @@ stationRoutes.post('/stations/search', async (c) => {
   const db = createDb(c.env.DB);
   const apiKey = c.env.GOOGLE_MAPS_API_KEY;
   // 末尾の「駅」を除去して正規化（「新宿駅」→「新宿」）
-  // Google Autocomplete API に types=train_station|subway_station と併用すると
-  // 「駅」付きの入力では結果が返らないことがあるため
   const input = body.input.trim().replace(/駅$/, '');
+  const textSearchQuery = `${input}駅`;
 
-  const cacheKey = input;
-
-  // Check cache
-  const cached = await getCache<GoogleAutocompletePrediction[]>(
+  // --- Autocomplete predictions (cache check) ---
+  const cachedPredictions = await getCache<GoogleAutocompletePrediction[]>(
     db,
     'station_predictions',
-    cacheKey,
+    input,
   );
 
+  // --- Text Search exact match (cache check) ---
+  const cachedTextSearch = await getCache<GooglePlaceResult[]>(
+    db,
+    'station_text_search',
+    input,
+  );
+
+  // Fetch uncached results in parallel
+  const [predictionsResult, textSearchResult] = await Promise.all([
+    cachedPredictions
+      ? Promise.resolve(null)
+      : getAutocompletePredictions(apiKey, input),
+    cachedTextSearch
+      ? Promise.resolve(null)
+      : searchStationByText(apiKey, textSearchQuery),
+  ]);
+
+  // Process autocomplete predictions
   let predictions: GoogleAutocompletePrediction[];
-  if (cached) {
-    predictions = cached;
-  } else {
-    // Call Google Autocomplete API
-    const result = await getAutocompletePredictions(apiKey, input);
-
-    if (!result.ok) {
-      return c.json({ success: false, error: result.error }, 500);
-    }
-
-    predictions = result.data;
-
-    // Store in cache
+  if (cachedPredictions) {
+    predictions = cachedPredictions;
+  } else if (predictionsResult && predictionsResult.ok) {
+    predictions = predictionsResult.data;
     await setCache(
       db,
       'station_predictions',
-      cacheKey,
+      input,
       predictions,
       CACHE_TTL.station_predictions,
     );
+  } else {
+    // Autocomplete failed — return error only if text search also fails
+    predictions = [];
   }
 
-  // Autocomplete API にはリクエスト時に types=train_station|subway_station を
-  // 指定済みなので、レスポンスは既に駅に限定されている。
-  // ここで isStation フィルタをかけると、Google が types フィールドに
-  // transit_station のみを返したり undefined を返した場合に候補が消えてしまう。
-  const stations: Station[] = predictions.map(predictionToStation);
+  // Process text search results (take first match only)
+  let exactMatches: GooglePlaceResult[];
+  if (cachedTextSearch) {
+    exactMatches = cachedTextSearch;
+  } else if (textSearchResult && textSearchResult.ok) {
+    // Keep only the first result — the most relevant exact match
+    exactMatches = textSearchResult.data.slice(0, 1);
+    await setCache(
+      db,
+      'station_text_search',
+      input,
+      exactMatches,
+      CACHE_TTL.station_text_search,
+    );
+  } else {
+    // Text search failed — continue with autocomplete results only
+    exactMatches = [];
+  }
+
+  // Convert to Station[]
+  const autocompleteStations = predictions.map(predictionToStation);
+  const exactStations = exactMatches.map((p) => placeToStation(p));
+
+  // Merge: exact matches first, then autocomplete (deduplicated by place_id)
+  const seenPlaceIds = new Set(exactStations.map((s) => s.placeId));
+  const deduped = autocompleteStations.filter(
+    (s) => !seenPlaceIds.has(s.placeId),
+  );
+  const stations = [...exactStations, ...deduped];
+
+  if (stations.length === 0 && predictionsResult && !predictionsResult.ok) {
+    return c.json({ success: false, error: predictionsResult.error }, 500);
+  }
 
   return c.json({ success: true, data: stations });
 });

--- a/worker/src/services/cache.ts
+++ b/worker/src/services/cache.ts
@@ -8,6 +8,7 @@ export const CACHE_TTL = {
   restaurant_search: 172800, // 48h
   geocode_forward: 604800, // 7d
   station_predictions: 86400, // 24h
+  station_text_search: 86400, // 24h
   nearby_stations: 604800, // 7d
   geocode_reverse: 86400, // 24h
   place_detail: 1209600, // 14d

--- a/worker/src/services/google-maps.test.ts
+++ b/worker/src/services/google-maps.test.ts
@@ -153,7 +153,7 @@ describe('getAutocompletePredictions', () => {
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     expect(calledUrl).toContain('autocomplete');
     expect(calledUrl).toContain('country%3Ajp');
-    expect(calledUrl).toContain('train_station');
+    expect(calledUrl).toContain('transit_station');
     expect(calledUrl).not.toContain('airport');
   });
 });

--- a/worker/src/services/google-maps.ts
+++ b/worker/src/services/google-maps.ts
@@ -63,7 +63,7 @@ export async function getAutocompletePredictions(
 ): Promise<Result<GoogleAutocompletePrediction[]>> {
   const params = new URLSearchParams({
     input,
-    types: 'train_station|subway_station',
+    types: 'train_station|subway_station|transit_station',
     components: 'country:jp',
     language: 'ja',
     key: apiKey,

--- a/worker/src/services/google-maps.ts
+++ b/worker/src/services/google-maps.ts
@@ -2,6 +2,7 @@ import type {
   Result,
   GoogleNearbySearchResponse,
   GoogleAutocompleteResponse,
+  GoogleTextSearchResponse,
   GoogleGeocodeResponse,
   GooglePlaceResult,
   GoogleAutocompletePrediction,
@@ -63,7 +64,7 @@ export async function getAutocompletePredictions(
 ): Promise<Result<GoogleAutocompletePrediction[]>> {
   const params = new URLSearchParams({
     input,
-    types: 'train_station|subway_station|transit_station',
+    types: 'transit_station',
     components: 'country:jp',
     language: 'ja',
     key: apiKey,
@@ -89,6 +90,44 @@ export async function getAutocompletePredictions(
   }
 
   return { ok: true, data: data.predictions };
+}
+
+/**
+ * Search for a station by name using Google Places Text Search REST API.
+ * Used to supplement autocomplete results with exact station matches.
+ */
+export async function searchStationByText(
+  apiKey: string,
+  query: string,
+): Promise<Result<GooglePlaceResult[]>> {
+  const params = new URLSearchParams({
+    query,
+    type: 'train_station',
+    language: 'ja',
+    region: 'jp',
+    key: apiKey,
+  });
+
+  const url = `${MAPS_BASE_URL}/maps/api/place/textsearch/json?${params.toString()}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: `Google Text Search API request failed: ${response.status} ${response.statusText}`,
+    };
+  }
+
+  const data: GoogleTextSearchResponse = await response.json();
+
+  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+    return {
+      ok: false,
+      error: `Google Text Search API error: ${data.status}`,
+    };
+  }
+
+  return { ok: true, data: data.results };
 }
 
 /**

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -76,6 +76,7 @@ export interface GooglePlaceResult {
   place_id: string;
   name: string;
   vicinity: string;
+  formatted_address?: string;
   rating?: number;
   user_ratings_total?: number;
   price_level?: number;
@@ -94,6 +95,11 @@ export interface GoogleNearbySearchResponse {
   results: GooglePlaceResult[];
   status: string;
   next_page_token?: string;
+}
+
+export interface GoogleTextSearchResponse {
+  results: GooglePlaceResult[];
+  status: string;
 }
 
 export interface GoogleAutocompletePrediction {


### PR DESCRIPTION
## Summary

- Google Places Autocomplete APIは予測補完APIのため、「新宿」入力時に「新宿三丁目駅」等の具体的候補を優先し、メインの「新宿駅」を返さなかった
- Text Search APIを並列実行して `{input}駅` の完全一致を取得し、Autocomplete結果と `place_id` ベースで重複除去してマージする方式に変更
- D1キャッシュ（24h TTL）により2回目以降のAPIコスト増はゼロ

## Changes

| ファイル | 変更内容 |
|---|---|
| `worker/src/services/google-maps.ts` | `searchStationByText` 関数追加、Autocomplete の types を `transit_station` に簡素化 |
| `worker/src/routes/stations.ts` | Autocomplete + Text Search の並列実行→マージロジック実装 |
| `worker/src/types.ts` | `GooglePlaceResult` に `formatted_address?` 追加、`GoogleTextSearchResponse` 追加 |
| `worker/src/services/cache.ts` | `station_text_search` キャッシュTTL（24h）追加 |
| `worker/src/lib/station-filter.ts` | `STATION_TYPES` に `transit_station` 追加 |

## Test plan

- [ ] 「新宿」入力 → 候補に「新宿駅」が含まれること
- [ ] 「新宿駅」入力 → 候補に「新宿駅」が含まれること
- [ ] 「渋谷」入力 → 候補に「渋谷駅」が含まれること
- [ ] 既存の周辺駅候補（新宿三丁目駅等）も引き続き表示されること
- [ ] Text Search API失敗時にAutocomplete結果のみで正常応答すること
- [ ] `npm run test` 全テスト通過

https://claude.ai/code/session_01T7X9WMkjpzqDAnKynDp82H