### PR TITLE
feat: 食べ物カテゴリを大幅に拡充

### DIFF
--- a/src/utils/keywordOptions.test.ts
+++ b/src/utils/keywordOptions.test.ts
@@ -7,13 +7,19 @@ import {
 
 describe('keywordOptions', () => {
   describe('keywordCategories', () => {
-    it('has four categories', () => {
-      expect(keywordCategories).toHaveLength(4);
+    it('has five categories', () => {
+      expect(keywordCategories).toHaveLength(5);
     });
 
     it('contains expected category names', () => {
       const names = keywordCategories.map((c) => c.name);
-      expect(names).toEqual(['食事', 'ジャンル', 'スタイル', '料理']);
+      expect(names).toEqual([
+        '食事',
+        'ジャンル',
+        'スタイル',
+        '料理',
+        'パン・スイーツ',
+      ]);
     });
 
     it('each category has at least one keyword', () => {

--- a/src/utils/keywordOptions.ts
+++ b/src/utils/keywordOptions.ts
@@ -27,6 +27,9 @@ export const keywordCategories = [
       { value: 'ファストフード', label: 'ファストフード' },
       { value: 'ファミレス', label: 'ファミレス' },
       { value: 'カフェ', label: 'カフェ' },
+      { value: '居酒屋', label: '居酒屋' },
+      { value: 'バー', label: 'バー' },
+      { value: '食べ放題', label: '食べ放題' },
     ],
   },
   {
@@ -34,6 +37,8 @@ export const keywordCategories = [
     keywords: [
       { value: 'ラーメン', label: 'ラーメン' },
       { value: 'うどん,そば', label: 'うどん,そば' },
+      { value: 'カレー', label: 'カレー' },
+      { value: '寿司', label: '寿司' },
       { value: '天ぷら', label: '天ぷら' },
       { value: 'とんかつ', label: 'とんかつ' },
       { value: '焼き鳥', label: '焼き鳥' },
@@ -41,6 +46,22 @@ export const keywordCategories = [
       { value: '焼肉', label: '焼肉' },
       { value: 'ステーキ', label: 'ステーキ' },
       { value: 'ハンバーグ', label: 'ハンバーグ' },
+      { value: 'ピザ', label: 'ピザ' },
+      { value: 'パスタ', label: 'パスタ' },
+      { value: '丼もの', label: '丼もの' },
+      { value: '餃子', label: '餃子' },
+      { value: 'たこ焼き,お好み焼き', label: 'たこ焼き,お好み焼き' },
+    ],
+  },
+  {
+    name: 'パン・スイーツ',
+    keywords: [
+      { value: 'パン', label: 'パン' },
+      { value: 'ケーキ', label: 'ケーキ' },
+      { value: 'スイーツ', label: 'スイーツ' },
+      { value: 'ドーナツ', label: 'ドーナツ' },
+      { value: 'クレープ', label: 'クレープ' },
+      { value: 'アイスクリーム', label: 'アイスクリーム' },
     ],
   },
 ];


### PR DESCRIPTION
スタイルに居酒屋・バー・食べ放題を追加。
料理にカレー・寿司・ピザ・パスタ・丼もの・餃子・たこ焼き/お好み焼きを追加。
パン・スイーツカテゴリを新設し、パン・ケーキ・スイーツ・ドーナツ・クレープ・アイスクリームを追加。
21キーワード → 37キーワードに拡充。

https://claude.ai/code/session_01EpUB4eFhkCaFWpjWVsiHiV