### PR TITLE
fix: モバイル検索条件スクロール修正 + 検索結果数改善

### DIFF
--- a/src/components/UnifiedSearchResultsScreen/index.tsx
+++ b/src/components/UnifiedSearchResultsScreen/index.tsx
@@ -178,7 +178,7 @@ const UnifiedSearchResultsScreen: React.FC<UnifiedSearchResultsScreenProps> = ({
   return (
     <div className="max-w-4xl mx-auto pb-20">
       {/* ===== Header ===== */}
-      <div className="sticky top-0 z-20 bg-surface">
+      <div className="sticky top-0 z-20 bg-surface max-h-dvh overflow-y-auto overscroll-contain">
         {/* Location Bar */}
         <div className="p-4 border-b border-primary-100">
           <div className="flex items-center gap-3">

--- a/worker/src/errors.ts
+++ b/worker/src/errors.ts
@@ -1,0 +1,6 @@
+import { Data } from 'effect';
+
+/** Google Maps API呼び出しエラー */
+export class GoogleMapsApiError extends Data.TaggedError('GoogleMapsApiError')<{
+  readonly message: string;
+}> {}

--- a/worker/src/routes/geocode.ts
+++ b/worker/src/routes/geocode.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { Effect } from 'effect';
 import { createDb } from '../db';
 import { getCache, setCache, CACHE_TTL } from '../services/cache';
 import { geocodeForward, geocodeReverse } from '../services/google-maps';
@@ -43,13 +44,18 @@ geocodeRoutes.post('/geocode/forward', async (c) => {
   if (cached) {
     results = cached;
   } else {
-    const result = await geocodeForward(apiKey, address);
+    const exit = await Effect.runPromiseExit(geocodeForward(apiKey, address));
 
-    if (!result.ok) {
-      return c.json({ success: false, error: result.error }, 500);
+    if (exit._tag === 'Failure') {
+      const error = exit.cause;
+      const message =
+        error._tag === 'Fail'
+          ? error.error.message
+          : '位置を取得できませんでした';
+      return c.json({ success: false, error: message }, 500);
     }
 
-    results = result.data;
+    results = exit.value;
 
     // Store in cache
     await setCache(
@@ -107,13 +113,18 @@ geocodeRoutes.post('/geocode/reverse', async (c) => {
   if (cached) {
     results = cached;
   } else {
-    const result = await geocodeReverse(apiKey, lat, lng);
+    const exit = await Effect.runPromiseExit(geocodeReverse(apiKey, lat, lng));
 
-    if (!result.ok) {
-      return c.json({ success: false, error: result.error }, 500);
+    if (exit._tag === 'Failure') {
+      const error = exit.cause;
+      const message =
+        error._tag === 'Fail'
+          ? error.error.message
+          : '住所を取得できませんでした';
+      return c.json({ success: false, error: message }, 500);
     }
 
-    results = result.data;
+    results = exit.value;
 
     // Store in cache
     await setCache(

--- a/worker/src/routes/restaurants.ts
+++ b/worker/src/routes/restaurants.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { Effect } from 'effect';
 import { createDb } from '../db';
 import {
   getCache,
@@ -103,67 +104,71 @@ restaurantRoutes.post('/restaurants/search', async (c) => {
   const apiKey = c.env.GOOGLE_MAPS_API_KEY;
   const { keywords, location, stationPlaceId } = body;
 
-  // Start all keyword fetches in parallel
-  const pending = keywords.map(async (keyword) => {
-    // キャッシュキーに半径を含めない（常に SEARCH_MAX_RADIUS で検索するため）
-    const cacheKey = `${keyword}-${stationPlaceId}`;
+  // キーワードごとの検索を Effect で構築
+  const fetchKeyword = (keyword: string) =>
+    Effect.gen(function* () {
+      const cacheKey = `${keyword}-${stationPlaceId}`;
 
-    // Check search result cache (place_id list)
-    const cachedPlaceIds = await getCache<string[]>(
-      db,
-      'restaurant_search',
-      cacheKey,
-    );
+      // Check search result cache (place_id list)
+      const cachedPlaceIds = yield* Effect.promise(() =>
+        getCache<string[]>(db, 'restaurant_search', cacheKey),
+      );
 
-    if (cachedPlaceIds) {
-      // Fetch details from place_cache
-      const placeMap = await getPlacesByIds(db, cachedPlaceIds);
-      return { keyword, placeMap, error: undefined };
-    }
+      if (cachedPlaceIds) {
+        const placeMap = yield* Effect.promise(() =>
+          getPlacesByIds(db, cachedPlaceIds),
+        );
+        return { keyword, placeMap };
+      }
 
-    // Cache miss - call Google Maps API（常に最大半径で検索）
-    const result = await searchNearbyPlaces(
-      apiKey,
-      location.lat,
-      location.lng,
-      SEARCH_MAX_RADIUS,
-      keyword,
-    );
-
-    if (!result.ok) {
-      return {
+      // Cache miss - call Google Maps API（常に最大半径で検索）
+      const places = yield* searchNearbyPlaces(
+        apiKey,
+        location.lat,
+        location.lng,
+        SEARCH_MAX_RADIUS,
         keyword,
-        placeMap: new Map<string, PlaceCacheRow>(),
-        error: result.error,
-      };
-    }
+      );
 
-    // Upsert each place into place_cache
-    await upsertPlaces(db, result.data);
+      // Upsert each place into place_cache
+      yield* Effect.promise(() => upsertPlaces(db, places));
 
-    // Save place_id list to api_cache
-    const placeIds = result.data.map((p) => p.place_id);
-    await setCache(
-      db,
-      'restaurant_search',
-      cacheKey,
-      placeIds,
-      CACHE_TTL.restaurant_search,
-    );
+      // Save place_id list to api_cache
+      const placeIds = places.map((p) => p.place_id);
+      yield* Effect.promise(() =>
+        setCache(
+          db,
+          'restaurant_search',
+          cacheKey,
+          placeIds,
+          CACHE_TTL.restaurant_search,
+        ),
+      );
 
-    // Build map from fresh data
-    const placeMap = await getPlacesByIds(db, placeIds);
-    return { keyword, placeMap, error: undefined };
+      // Build map from fresh data
+      const placeMap = yield* Effect.promise(() =>
+        getPlacesByIds(db, placeIds),
+      );
+      return { keyword, placeMap };
+    });
+
+  // 全キーワードを並列実行
+  const program = Effect.all(keywords.map(fetchKeyword), {
+    concurrency: 'unbounded',
   });
 
-  const keywordResults = [];
-  for (const p of pending) {
-    const result = await p;
-    if (result.error) {
-      return c.json({ success: false, error: result.error }, 500);
-    }
-    keywordResults.push(result);
+  const exit = await Effect.runPromiseExit(program);
+
+  if (exit._tag === 'Failure') {
+    const error = exit.cause;
+    const message =
+      error._tag === 'Fail'
+        ? error.error.message
+        : 'レストラン検索中にエラーが発生しました';
+    return c.json({ success: false, error: message }, 500);
   }
+
+  const keywordResults = exit.value;
 
   // Combine and deduplicate results by place_id
   const restaurantMap = new Map<string, Restaurant>();

--- a/worker/src/routes/restaurants.ts
+++ b/worker/src/routes/restaurants.ts
@@ -122,7 +122,7 @@ restaurantRoutes.post('/restaurants/search', async (c) => {
       }
 
       // Cache miss - call Google Maps API（常に最大半径で検索）
-      const places = yield* searchNearbyPlaces(
+      const { results: places, complete } = yield* searchNearbyPlaces(
         apiKey,
         location.lat,
         location.lng,
@@ -133,17 +133,19 @@ restaurantRoutes.post('/restaurants/search', async (c) => {
       // Upsert each place into place_cache
       yield* Effect.promise(() => upsertPlaces(db, places));
 
-      // Save place_id list to api_cache
+      // 完全な結果のみキャッシュ（不完全な結果は次回再取得させる）
       const placeIds = places.map((p) => p.place_id);
-      yield* Effect.promise(() =>
-        setCache(
-          db,
-          'restaurant_search',
-          cacheKey,
-          placeIds,
-          CACHE_TTL.restaurant_search,
-        ),
-      );
+      if (complete) {
+        yield* Effect.promise(() =>
+          setCache(
+            db,
+            'restaurant_search',
+            cacheKey,
+            placeIds,
+            CACHE_TTL.restaurant_search,
+          ),
+        );
+      }
 
       // Build map from fresh data
       const placeMap = yield* Effect.promise(() =>

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { Effect } from 'effect';
 import { createDb } from '../db';
 import { getCache, setCache, CACHE_TTL } from '../services/cache';
 import {
@@ -112,23 +113,27 @@ stationRoutes.post('/stations/search', async (c) => {
     input,
   );
 
-  // Fetch uncached results in parallel
-  // oxlint-disable-next-line effect-enforce/no-promise-static-methods -- Worker側はEffectを使用していない
-  const [predictionsResult, textSearchResult] = await Promise.all([
-    cachedPredictions
-      ? Promise.resolve(null)
-      : getAutocompletePredictions(apiKey, input),
-    cachedTextSearch
-      ? Promise.resolve(null)
-      : searchStationByText(apiKey, textSearchQuery),
-  ]);
+  // Fetch uncached results in parallel via Effect.all
+  const predictionsEffect = cachedPredictions
+    ? Effect.succeed(null)
+    : Effect.either(getAutocompletePredictions(apiKey, input));
+
+  const textSearchEffect = cachedTextSearch
+    ? Effect.succeed(null)
+    : Effect.either(searchStationByText(apiKey, textSearchQuery));
+
+  const [predictionsResult, textSearchResult] = await Effect.runPromise(
+    Effect.all([predictionsEffect, textSearchEffect], {
+      concurrency: 'unbounded',
+    }),
+  );
 
   // Process autocomplete predictions
   let predictions: GoogleAutocompletePrediction[];
   if (cachedPredictions) {
     predictions = cachedPredictions;
-  } else if (predictionsResult && predictionsResult.ok) {
-    predictions = predictionsResult.data;
+  } else if (predictionsResult && predictionsResult._tag === 'Right') {
+    predictions = predictionsResult.right;
     await setCache(
       db,
       'station_predictions',
@@ -145,9 +150,9 @@ stationRoutes.post('/stations/search', async (c) => {
   let exactMatches: GooglePlaceResult[];
   if (cachedTextSearch) {
     exactMatches = cachedTextSearch;
-  } else if (textSearchResult && textSearchResult.ok) {
+  } else if (textSearchResult && textSearchResult._tag === 'Right') {
     // Keep only the first result — the most relevant exact match
-    exactMatches = textSearchResult.data.slice(0, 1);
+    exactMatches = textSearchResult.right.slice(0, 1);
     await setCache(
       db,
       'station_text_search',
@@ -171,8 +176,15 @@ stationRoutes.post('/stations/search', async (c) => {
   );
   const stations = [...exactStations, ...deduped];
 
-  if (stations.length === 0 && predictionsResult && !predictionsResult.ok) {
-    return c.json({ success: false, error: predictionsResult.error }, 500);
+  if (
+    stations.length === 0 &&
+    predictionsResult &&
+    predictionsResult._tag === 'Left'
+  ) {
+    return c.json(
+      { success: false, error: predictionsResult.left.message },
+      500,
+    );
   }
 
   return c.json({ success: true, data: stations });
@@ -210,13 +222,20 @@ stationRoutes.post('/stations/nearby', async (c) => {
     // Search for train stations within 5km
     // type を指定しないことで subway_station のみの駅も漏れなく取得し、
     // isStation フィルタで train_station / subway_station に絞る
-    const result = await searchNearbyPlaces(apiKey, lat, lng, 5000, '駅');
+    const exit = await Effect.runPromiseExit(
+      searchNearbyPlaces(apiKey, lat, lng, 5000, '駅'),
+    );
 
-    if (!result.ok) {
-      return c.json({ success: false, error: result.error }, 500);
+    if (exit._tag === 'Failure') {
+      const error = exit.cause;
+      const message =
+        error._tag === 'Fail'
+          ? error.error.message
+          : '近くの駅の検索に失敗しました';
+      return c.json({ success: false, error: message }, 500);
     }
 
-    places = result.data;
+    places = exit.value;
 
     // Store in cache
     await setCache(

--- a/worker/src/routes/stations.ts
+++ b/worker/src/routes/stations.ts
@@ -235,16 +235,18 @@ stationRoutes.post('/stations/nearby', async (c) => {
       return c.json({ success: false, error: message }, 500);
     }
 
-    places = exit.value;
+    places = exit.value.results;
 
-    // Store in cache
-    await setCache(
-      db,
-      'nearby_stations',
-      cacheKey,
-      places,
-      CACHE_TTL.nearby_stations,
-    );
+    // 完全な結果のみキャッシュ
+    if (exit.value.complete) {
+      await setCache(
+        db,
+        'nearby_stations',
+        cacheKey,
+        places,
+        CACHE_TTL.nearby_stations,
+      );
+    }
   }
 
   // Convert to Station[], filter to actual stations, sort by distance, take top 5

--- a/worker/src/services/google-maps.test.ts
+++ b/worker/src/services/google-maps.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Effect } from 'effect';
 import {
   searchNearbyPlaces,
   getAutocompletePredictions,
@@ -15,7 +16,7 @@ beforeEach(() => {
 });
 
 describe('searchNearbyPlaces', () => {
-  it('returns ok result on OK status', async () => {
+  it('returns results on OK status', async () => {
     const mockResults = [
       { place_id: 'p1', name: 'Restaurant A', vicinity: 'Tokyo' },
     ];
@@ -24,14 +25,10 @@ describe('searchNearbyPlaces', () => {
       json: async () => ({ results: mockResults, status: 'OK' }),
     });
 
-    const result = await searchNearbyPlaces(
-      'test-key',
-      35.68,
-      139.76,
-      1000,
-      'ramen',
+    const result = await Effect.runPromise(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result).toEqual({ ok: true, data: mockResults });
+    expect(result).toEqual(mockResults);
     expect(mockFetch).toHaveBeenCalledOnce();
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
@@ -40,59 +37,41 @@ describe('searchNearbyPlaces', () => {
     expect(calledUrl).toContain('key=test-key');
   });
 
-  it('returns ok with empty array on ZERO_RESULTS', async () => {
+  it('returns empty array on ZERO_RESULTS', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ results: [], status: 'ZERO_RESULTS' }),
     });
 
-    const result = await searchNearbyPlaces(
-      'test-key',
-      35.68,
-      139.76,
-      1000,
-      'ramen',
+    const result = await Effect.runPromise(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result).toEqual({ ok: true, data: [] });
+    expect(result).toEqual([]);
   });
 
-  it('returns error on HTTP error', async () => {
+  it('fails on HTTP error', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
     });
 
-    const result = await searchNearbyPlaces(
-      'test-key',
-      35.68,
-      139.76,
-      1000,
-      'ramen',
+    const exit = await Effect.runPromiseExit(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('request failed: 500');
-    }
+    expect(exit._tag).toBe('Failure');
   });
 
-  it('returns error on API error status', async () => {
+  it('fails on API error status', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ results: [], status: 'REQUEST_DENIED' }),
     });
 
-    const result = await searchNearbyPlaces(
-      'test-key',
-      35.68,
-      139.76,
-      1000,
-      'ramen',
+    const exit = await Effect.runPromiseExit(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('REQUEST_DENIED');
-    }
+    expect(exit._tag).toBe('Failure');
   });
 
   it('includes type parameter when provided', async () => {
@@ -101,13 +80,15 @@ describe('searchNearbyPlaces', () => {
       json: async () => ({ results: [], status: 'ZERO_RESULTS' }),
     });
 
-    await searchNearbyPlaces(
-      'test-key',
-      35.68,
-      139.76,
-      5000,
-      '駅',
-      'train_station',
+    await Effect.runPromise(
+      searchNearbyPlaces(
+        'test-key',
+        35.68,
+        139.76,
+        5000,
+        '駅',
+        'train_station',
+      ),
     );
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
@@ -120,15 +101,48 @@ describe('searchNearbyPlaces', () => {
       json: async () => ({ results: [], status: 'ZERO_RESULTS' }),
     });
 
-    await searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen');
+    await Effect.runPromise(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
+    );
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     expect(calledUrl).not.toContain('type=');
   });
+
+  it('fetches multiple pages when next_page_token is present', async () => {
+    const page1Results = [{ place_id: 'p1', name: 'A', vicinity: 'Tokyo' }];
+    const page2Results = [{ place_id: 'p2', name: 'B', vicinity: 'Tokyo' }];
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: page1Results,
+          status: 'OK',
+          next_page_token: 'token123',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: page2Results,
+          status: 'OK',
+        }),
+      });
+
+    const result = await Effect.runPromise(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
+    );
+    expect(result).toEqual([...page1Results, ...page2Results]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const secondUrl = mockFetch.mock.calls[1][0] as string;
+    expect(secondUrl).toContain('pagetoken=token123');
+  });
 });
 
 describe('getAutocompletePredictions', () => {
-  it('returns ok result on OK status', async () => {
+  it('returns predictions on OK status', async () => {
     const mockPredictions = [
       {
         place_id: 'p1',
@@ -147,8 +161,10 @@ describe('getAutocompletePredictions', () => {
       }),
     });
 
-    const result = await getAutocompletePredictions('test-key', '新宿');
-    expect(result).toEqual({ ok: true, data: mockPredictions });
+    const result = await Effect.runPromise(
+      getAutocompletePredictions('test-key', '新宿'),
+    );
+    expect(result).toEqual(mockPredictions);
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     expect(calledUrl).toContain('autocomplete');
@@ -159,7 +175,7 @@ describe('getAutocompletePredictions', () => {
 });
 
 describe('geocodeForward', () => {
-  it('returns ok result on OK status', async () => {
+  it('returns results on OK status', async () => {
     const mockResults = [
       {
         formatted_address: '東京都新宿区',
@@ -171,13 +187,15 @@ describe('geocodeForward', () => {
       json: async () => ({ results: mockResults, status: 'OK' }),
     });
 
-    const result = await geocodeForward('test-key', '新宿駅');
-    expect(result).toEqual({ ok: true, data: mockResults });
+    const result = await Effect.runPromise(
+      geocodeForward('test-key', '新宿駅'),
+    );
+    expect(result).toEqual(mockResults);
   });
 });
 
 describe('geocodeReverse', () => {
-  it('returns ok result on OK status', async () => {
+  it('returns results on OK status', async () => {
     const mockResults = [
       {
         formatted_address: '東京都千代田区丸の内',
@@ -189,8 +207,10 @@ describe('geocodeReverse', () => {
       json: async () => ({ results: mockResults, status: 'OK' }),
     });
 
-    const result = await geocodeReverse('test-key', 35.6812, 139.7671);
-    expect(result).toEqual({ ok: true, data: mockResults });
+    const result = await Effect.runPromise(
+      geocodeReverse('test-key', 35.6812, 139.7671),
+    );
+    expect(result).toEqual(mockResults);
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
     expect(calledUrl).toContain('latlng=35.6812');

--- a/worker/src/services/google-maps.test.ts
+++ b/worker/src/services/google-maps.test.ts
@@ -139,6 +139,70 @@ describe('searchNearbyPlaces', () => {
     const secondUrl = mockFetch.mock.calls[1][0] as string;
     expect(secondUrl).toContain('pagetoken=token123');
   });
+
+  it('retries on INVALID_REQUEST for paginated requests and succeeds', async () => {
+    const page1Results = [{ place_id: 'p1', name: 'A', vicinity: 'Tokyo' }];
+    const page2Results = [{ place_id: 'p2', name: 'B', vicinity: 'Tokyo' }];
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: page1Results,
+          status: 'OK',
+          next_page_token: 'token456',
+        }),
+      })
+      // First attempt: INVALID_REQUEST (token not yet valid)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [],
+          status: 'INVALID_REQUEST',
+        }),
+      })
+      // Retry succeeds
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: page2Results,
+          status: 'OK',
+        }),
+      });
+
+    const result = await Effect.runPromise(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
+    );
+    expect(result).toEqual([...page1Results, ...page2Results]);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns partial results when paginated request fails with non-transient error', async () => {
+    const page1Results = [{ place_id: 'p1', name: 'A', vicinity: 'Tokyo' }];
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: page1Results,
+          status: 'OK',
+          next_page_token: 'token789',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [],
+          status: 'REQUEST_DENIED',
+        }),
+      });
+
+    const result = await Effect.runPromise(
+      searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
+    );
+    // Should return page 1 results instead of failing entirely
+    expect(result).toEqual(page1Results);
+  });
 });
 
 describe('getAutocompletePredictions', () => {

--- a/worker/src/services/google-maps.test.ts
+++ b/worker/src/services/google-maps.test.ts
@@ -28,7 +28,7 @@ describe('searchNearbyPlaces', () => {
     const result = await Effect.runPromise(
       searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result).toEqual(mockResults);
+    expect(result).toEqual({ results: mockResults, complete: true });
     expect(mockFetch).toHaveBeenCalledOnce();
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
@@ -46,7 +46,7 @@ describe('searchNearbyPlaces', () => {
     const result = await Effect.runPromise(
       searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result).toEqual([]);
+    expect(result).toEqual({ results: [], complete: true });
   });
 
   it('fails on HTTP error', async () => {
@@ -133,7 +133,10 @@ describe('searchNearbyPlaces', () => {
     const result = await Effect.runPromise(
       searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result).toEqual([...page1Results, ...page2Results]);
+    expect(result).toEqual({
+      results: [...page1Results, ...page2Results],
+      complete: true,
+    });
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
     const secondUrl = mockFetch.mock.calls[1][0] as string;
@@ -173,7 +176,10 @@ describe('searchNearbyPlaces', () => {
     const result = await Effect.runPromise(
       searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    expect(result).toEqual([...page1Results, ...page2Results]);
+    expect(result).toEqual({
+      results: [...page1Results, ...page2Results],
+      complete: true,
+    });
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
@@ -200,8 +206,8 @@ describe('searchNearbyPlaces', () => {
     const result = await Effect.runPromise(
       searchNearbyPlaces('test-key', 35.68, 139.76, 1000, 'ramen'),
     );
-    // Should return page 1 results instead of failing entirely
-    expect(result).toEqual(page1Results);
+    // Should return page 1 results as incomplete instead of failing entirely
+    expect(result).toEqual({ results: page1Results, complete: false });
   });
 });
 

--- a/worker/src/services/google-maps.ts
+++ b/worker/src/services/google-maps.ts
@@ -1,5 +1,6 @@
+import { Effect } from 'effect';
+import { GoogleMapsApiError } from '../errors';
 import type {
-  Result,
   GoogleNearbySearchResponse,
   GoogleAutocompleteResponse,
   GoogleTextSearchResponse,
@@ -17,217 +18,201 @@ const MAX_PAGES = 3;
 /** next_page_token が有効になるまでの待機時間 (ms) */
 const PAGE_TOKEN_DELAY_MS = 2000;
 
-function delay(ms: number): Promise<void> {
-  // oxlint-disable-next-line effect-enforce/no-promise-constructor -- Worker側はEffectを使用しない
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+/**
+ * fetch して JSON をパースし、失敗時は GoogleMapsApiError にする共通ヘルパー
+ */
+const fetchGoogleApi = <T>(
+  url: string,
+  label: string,
+): Effect.Effect<T, GoogleMapsApiError> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () => fetch(url),
+      catch: () => new GoogleMapsApiError({ message: `${label} fetch failed` }),
+    });
+
+    if (!response.ok) {
+      return yield* Effect.fail(
+        new GoogleMapsApiError({
+          message: `${label} request failed: ${response.status} ${response.statusText}`,
+        }),
+      );
+    }
+
+    return yield* Effect.tryPromise({
+      try: () => response.json() as Promise<T>,
+      catch: () =>
+        new GoogleMapsApiError({ message: `${label} JSON parse failed` }),
+    });
+  });
+
+/**
+ * Google API のステータスを検証する
+ */
+const validateStatus = (
+  status: string,
+  label: string,
+): Effect.Effect<void, GoogleMapsApiError> =>
+  status === 'OK' || status === 'ZERO_RESULTS'
+    ? Effect.void
+    : Effect.fail(
+        new GoogleMapsApiError({ message: `${label} error: ${status}` }),
+      );
 
 /**
  * Search for nearby places using Google Maps Nearby Search REST API.
  * Automatically fetches subsequent pages via next_page_token (up to 60 results).
  */
-export async function searchNearbyPlaces(
+export const searchNearbyPlaces = (
   apiKey: string,
   lat: number,
   lng: number,
   radius: number,
   keyword: string,
   type?: string,
-): Promise<Result<GooglePlaceResult[]>> {
-  const baseParams = new URLSearchParams({
-    location: `${lat},${lng}`,
-    radius: String(radius),
-    keyword,
-    language: 'ja',
-    key: apiKey,
+): Effect.Effect<GooglePlaceResult[], GoogleMapsApiError> =>
+  Effect.gen(function* () {
+    const baseParams = new URLSearchParams({
+      location: `${lat},${lng}`,
+      radius: String(radius),
+      keyword,
+      language: 'ja',
+      key: apiKey,
+    });
+    if (type) {
+      baseParams.set('type', type);
+    }
+
+    const allResults: GooglePlaceResult[] = [];
+    let pageToken: string | undefined;
+
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const params = new URLSearchParams(baseParams);
+      if (pageToken) {
+        params.set('pagetoken', pageToken);
+      }
+
+      const url = `${MAPS_BASE_URL}/maps/api/place/nearbysearch/json?${params.toString()}`;
+      const data = yield* fetchGoogleApi<GoogleNearbySearchResponse>(
+        url,
+        'Google Nearby Search API',
+      );
+      yield* validateStatus(data.status, 'Google Nearby Search API');
+
+      allResults.push(...data.results);
+
+      if (!data.next_page_token) {
+        break;
+      }
+
+      pageToken = data.next_page_token;
+      yield* Effect.sleep(PAGE_TOKEN_DELAY_MS);
+    }
+
+    return allResults;
   });
-  if (type) {
-    baseParams.set('type', type);
-  }
-
-  const allResults: GooglePlaceResult[] = [];
-  let pageToken: string | undefined;
-
-  for (let page = 0; page < MAX_PAGES; page++) {
-    const params = new URLSearchParams(baseParams);
-    if (pageToken) {
-      params.set('pagetoken', pageToken);
-    }
-
-    const url = `${MAPS_BASE_URL}/maps/api/place/nearbysearch/json?${params.toString()}`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      return {
-        ok: false,
-        error: `Google Nearby Search API request failed: ${response.status} ${response.statusText}`,
-      };
-    }
-
-    const data: GoogleNearbySearchResponse = await response.json();
-
-    if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-      return {
-        ok: false,
-        error: `Google Nearby Search API error: ${data.status}`,
-      };
-    }
-
-    allResults.push(...data.results);
-
-    if (!data.next_page_token) {
-      break;
-    }
-
-    pageToken = data.next_page_token;
-    await delay(PAGE_TOKEN_DELAY_MS);
-  }
-
-  return { ok: true, data: allResults };
-}
 
 /**
  * Get autocomplete predictions for station search using Google Places Autocomplete REST API.
  */
-export async function getAutocompletePredictions(
+export const getAutocompletePredictions = (
   apiKey: string,
   input: string,
-): Promise<Result<GoogleAutocompletePrediction[]>> {
-  const params = new URLSearchParams({
-    input,
-    types: 'transit_station',
-    components: 'country:jp',
-    language: 'ja',
-    key: apiKey,
+): Effect.Effect<GoogleAutocompletePrediction[], GoogleMapsApiError> =>
+  Effect.gen(function* () {
+    const params = new URLSearchParams({
+      input,
+      types: 'transit_station',
+      components: 'country:jp',
+      language: 'ja',
+      key: apiKey,
+    });
+
+    const url = `${MAPS_BASE_URL}/maps/api/place/autocomplete/json?${params.toString()}`;
+    const data = yield* fetchGoogleApi<GoogleAutocompleteResponse>(
+      url,
+      'Google Autocomplete API',
+    );
+    yield* validateStatus(data.status, 'Google Autocomplete API');
+
+    return data.predictions;
   });
-
-  const url = `${MAPS_BASE_URL}/maps/api/place/autocomplete/json?${params.toString()}`;
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    return {
-      ok: false,
-      error: `Google Autocomplete API request failed: ${response.status} ${response.statusText}`,
-    };
-  }
-
-  const data: GoogleAutocompleteResponse = await response.json();
-
-  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-    return {
-      ok: false,
-      error: `Google Autocomplete API error: ${data.status}`,
-    };
-  }
-
-  return { ok: true, data: data.predictions };
-}
 
 /**
  * Search for a station by name using Google Places Text Search REST API.
  * Used to supplement autocomplete results with exact station matches.
  */
-export async function searchStationByText(
+export const searchStationByText = (
   apiKey: string,
   query: string,
-): Promise<Result<GooglePlaceResult[]>> {
-  const params = new URLSearchParams({
-    query,
-    type: 'train_station',
-    language: 'ja',
-    region: 'jp',
-    key: apiKey,
+): Effect.Effect<GooglePlaceResult[], GoogleMapsApiError> =>
+  Effect.gen(function* () {
+    const params = new URLSearchParams({
+      query,
+      type: 'train_station',
+      language: 'ja',
+      region: 'jp',
+      key: apiKey,
+    });
+
+    const url = `${MAPS_BASE_URL}/maps/api/place/textsearch/json?${params.toString()}`;
+    const data = yield* fetchGoogleApi<GoogleTextSearchResponse>(
+      url,
+      'Google Text Search API',
+    );
+    yield* validateStatus(data.status, 'Google Text Search API');
+
+    return data.results;
   });
-
-  const url = `${MAPS_BASE_URL}/maps/api/place/textsearch/json?${params.toString()}`;
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    return {
-      ok: false,
-      error: `Google Text Search API request failed: ${response.status} ${response.statusText}`,
-    };
-  }
-
-  const data: GoogleTextSearchResponse = await response.json();
-
-  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-    return {
-      ok: false,
-      error: `Google Text Search API error: ${data.status}`,
-    };
-  }
-
-  return { ok: true, data: data.results };
-}
 
 /**
  * Forward geocode: convert address to coordinates using Google Geocoding REST API.
  */
-export async function geocodeForward(
+export const geocodeForward = (
   apiKey: string,
   address: string,
-): Promise<Result<GoogleGeocodeResult[]>> {
-  const params = new URLSearchParams({
-    address,
-    language: 'ja',
-    key: apiKey,
+): Effect.Effect<GoogleGeocodeResult[], GoogleMapsApiError> =>
+  Effect.gen(function* () {
+    const params = new URLSearchParams({
+      address,
+      language: 'ja',
+      key: apiKey,
+    });
+
+    const url = `${MAPS_BASE_URL}/maps/api/geocode/json?${params.toString()}`;
+    const data = yield* fetchGoogleApi<GoogleGeocodeResponse>(
+      url,
+      'Google Geocoding API',
+    );
+    yield* validateStatus(data.status, 'Google Geocoding API');
+
+    return data.results;
   });
-
-  const url = `${MAPS_BASE_URL}/maps/api/geocode/json?${params.toString()}`;
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    return {
-      ok: false,
-      error: `Google Geocoding API request failed: ${response.status} ${response.statusText}`,
-    };
-  }
-
-  const data: GoogleGeocodeResponse = await response.json();
-
-  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-    return { ok: false, error: `Google Geocoding API error: ${data.status}` };
-  }
-
-  return { ok: true, data: data.results };
-}
 
 /**
  * Reverse geocode: convert coordinates to address using Google Geocoding REST API.
  */
-export async function geocodeReverse(
+export const geocodeReverse = (
   apiKey: string,
   lat: number,
   lng: number,
-): Promise<Result<GoogleGeocodeResult[]>> {
-  const params = new URLSearchParams({
-    latlng: `${lat},${lng}`,
-    language: 'ja',
-    key: apiKey,
+): Effect.Effect<GoogleGeocodeResult[], GoogleMapsApiError> =>
+  Effect.gen(function* () {
+    const params = new URLSearchParams({
+      latlng: `${lat},${lng}`,
+      language: 'ja',
+      key: apiKey,
+    });
+
+    const url = `${MAPS_BASE_URL}/maps/api/geocode/json?${params.toString()}`;
+    const data = yield* fetchGoogleApi<GoogleGeocodeResponse>(
+      url,
+      'Google Geocoding API (reverse)',
+    );
+    yield* validateStatus(data.status, 'Google Geocoding API (reverse)');
+
+    return data.results;
   });
-
-  const url = `${MAPS_BASE_URL}/maps/api/geocode/json?${params.toString()}`;
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    return {
-      ok: false,
-      error: `Google Geocoding API (reverse) request failed: ${response.status} ${response.statusText}`,
-    };
-  }
-
-  const data: GoogleGeocodeResponse = await response.json();
-
-  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-    return {
-      ok: false,
-      error: `Google Geocoding API (reverse) error: ${data.status}`,
-    };
-  }
-
-  return { ok: true, data: data.results };
-}
 
 /**
  * Construct a Google Maps Place Photo URL.

--- a/worker/src/services/google-maps.ts
+++ b/worker/src/services/google-maps.ts
@@ -24,6 +24,12 @@ const PAGE_TOKEN_MAX_RETRIES = 3;
 /** next_page_token リトライ間隔 (ms) */
 const PAGE_TOKEN_RETRY_DELAY_MS = 1000;
 
+/** searchNearbyPlaces の戻り値。complete が false の場合、結果が不完全なためキャッシュすべきでない */
+export interface NearbySearchResult {
+  readonly results: GooglePlaceResult[];
+  readonly complete: boolean;
+}
+
 /**
  * fetch して JSON をパースし、失敗時は GoogleMapsApiError にする共通ヘルパー
  */
@@ -76,7 +82,7 @@ export const searchNearbyPlaces = (
   radius: number,
   keyword: string,
   type?: string,
-): Effect.Effect<GooglePlaceResult[], GoogleMapsApiError> =>
+): Effect.Effect<NearbySearchResult, GoogleMapsApiError> =>
   Effect.gen(function* () {
     const baseParams = new URLSearchParams({
       location: `${lat},${lng}`,
@@ -130,8 +136,8 @@ export const searchNearbyPlaces = (
         );
 
         if (result._tag === 'Left') {
-          // fetch/parse 自体が失敗 → 取得済み結果を返す
-          return allResults;
+          // fetch/parse 自体が失敗 → 取得済み結果を返す（不完全）
+          return { results: allResults, complete: false };
         }
 
         const data = result.right;
@@ -146,8 +152,8 @@ export const searchNearbyPlaces = (
         }
 
         if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-          // 回復不能なエラー → 取得済み結果を返す
-          return allResults;
+          // 回復不能なエラー → 取得済み結果を返す（不完全）
+          return { results: allResults, complete: false };
         }
 
         allResults.push(...data.results);
@@ -163,7 +169,7 @@ export const searchNearbyPlaces = (
       yield* Effect.sleep(PAGE_TOKEN_DELAY_MS);
     }
 
-    return allResults;
+    return { results: allResults, complete: true };
   });
 
 /**

--- a/worker/src/services/google-maps.ts
+++ b/worker/src/services/google-maps.ts
@@ -11,8 +11,20 @@ import type {
 
 const MAPS_BASE_URL = 'https://maps.googleapis.com';
 
+/** Google Nearby Search API の最大ページ数（API上限は3ページ = 60件） */
+const MAX_PAGES = 3;
+
+/** next_page_token が有効になるまでの待機時間 (ms) */
+const PAGE_TOKEN_DELAY_MS = 2000;
+
+function delay(ms: number): Promise<void> {
+  // oxlint-disable-next-line effect-enforce/no-promise-constructor -- Worker側はEffectを使用しない
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Search for nearby places using Google Maps Nearby Search REST API.
+ * Automatically fetches subsequent pages via next_page_token (up to 60 results).
  */
 export async function searchNearbyPlaces(
   apiKey: string,
@@ -22,7 +34,7 @@ export async function searchNearbyPlaces(
   keyword: string,
   type?: string,
 ): Promise<Result<GooglePlaceResult[]>> {
-  const params = new URLSearchParams({
+  const baseParams = new URLSearchParams({
     location: `${lat},${lng}`,
     radius: String(radius),
     keyword,
@@ -30,29 +42,48 @@ export async function searchNearbyPlaces(
     key: apiKey,
   });
   if (type) {
-    params.set('type', type);
+    baseParams.set('type', type);
   }
 
-  const url = `${MAPS_BASE_URL}/maps/api/place/nearbysearch/json?${params.toString()}`;
-  const response = await fetch(url);
+  const allResults: GooglePlaceResult[] = [];
+  let pageToken: string | undefined;
 
-  if (!response.ok) {
-    return {
-      ok: false,
-      error: `Google Nearby Search API request failed: ${response.status} ${response.statusText}`,
-    };
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const params = new URLSearchParams(baseParams);
+    if (pageToken) {
+      params.set('pagetoken', pageToken);
+    }
+
+    const url = `${MAPS_BASE_URL}/maps/api/place/nearbysearch/json?${params.toString()}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: `Google Nearby Search API request failed: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const data: GoogleNearbySearchResponse = await response.json();
+
+    if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+      return {
+        ok: false,
+        error: `Google Nearby Search API error: ${data.status}`,
+      };
+    }
+
+    allResults.push(...data.results);
+
+    if (!data.next_page_token) {
+      break;
+    }
+
+    pageToken = data.next_page_token;
+    await delay(PAGE_TOKEN_DELAY_MS);
   }
 
-  const data: GoogleNearbySearchResponse = await response.json();
-
-  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
-    return {
-      ok: false,
-      error: `Google Nearby Search API error: ${data.status}`,
-    };
-  }
-
-  return { ok: true, data: data.results };
+  return { ok: true, data: allResults };
 }
 
 /**

--- a/worker/src/services/google-maps.ts
+++ b/worker/src/services/google-maps.ts
@@ -18,6 +18,12 @@ const MAX_PAGES = 3;
 /** next_page_token が有効になるまでの待機時間 (ms) */
 const PAGE_TOKEN_DELAY_MS = 2000;
 
+/** next_page_token 使用時の INVALID_REQUEST に対するリトライ回数 */
+const PAGE_TOKEN_MAX_RETRIES = 3;
+
+/** next_page_token リトライ間隔 (ms) */
+const PAGE_TOKEN_RETRY_DELAY_MS = 1000;
+
 /**
  * fetch して JSON をパースし、失敗時は GoogleMapsApiError にする共通ヘルパー
  */
@@ -93,19 +99,67 @@ export const searchNearbyPlaces = (
       }
 
       const url = `${MAPS_BASE_URL}/maps/api/place/nearbysearch/json?${params.toString()}`;
-      const data = yield* fetchGoogleApi<GoogleNearbySearchResponse>(
-        url,
-        'Google Nearby Search API',
-      );
-      yield* validateStatus(data.status, 'Google Nearby Search API');
 
-      allResults.push(...data.results);
+      // 1ページ目は通常通りfetch & validate
+      if (!pageToken) {
+        const data = yield* fetchGoogleApi<GoogleNearbySearchResponse>(
+          url,
+          'Google Nearby Search API',
+        );
+        yield* validateStatus(data.status, 'Google Nearby Search API');
 
-      if (!data.next_page_token) {
+        allResults.push(...data.results);
+
+        if (!data.next_page_token) {
+          break;
+        }
+
+        pageToken = data.next_page_token;
+        yield* Effect.sleep(PAGE_TOKEN_DELAY_MS);
+        continue;
+      }
+
+      // 2ページ目以降: INVALID_REQUEST はリトライ、それ以外のエラーは取得済み結果を返す
+      let fetched = false;
+      for (let retry = 0; retry <= PAGE_TOKEN_MAX_RETRIES; retry++) {
+        const result = yield* Effect.either(
+          fetchGoogleApi<GoogleNearbySearchResponse>(
+            url,
+            'Google Nearby Search API',
+          ),
+        );
+
+        if (result._tag === 'Left') {
+          // fetch/parse 自体が失敗 → 取得済み結果を返す
+          return allResults;
+        }
+
+        const data = result.right;
+
+        if (
+          data.status === 'INVALID_REQUEST' &&
+          retry < PAGE_TOKEN_MAX_RETRIES
+        ) {
+          // トークンがまだ有効化されていない → リトライ
+          yield* Effect.sleep(PAGE_TOKEN_RETRY_DELAY_MS);
+          continue;
+        }
+
+        if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+          // 回復不能なエラー → 取得済み結果を返す
+          return allResults;
+        }
+
+        allResults.push(...data.results);
+        pageToken = data.next_page_token;
+        fetched = true;
         break;
       }
 
-      pageToken = data.next_page_token;
+      if (!fetched || !pageToken) {
+        break;
+      }
+
       yield* Effect.sleep(PAGE_TOKEN_DELAY_MS);
     }
 


### PR DESCRIPTION
## Summary
- モバイルで検索条件パネルを開いた際、パネル内をスクロールできず検索結果側にスクロールが奪われる問題を修正
- Google Nearby Search APIのページネーションを実装し、キーワードあたり最大20件→60件まで取得可能に
- Worker側のGoogle Maps API呼び出しを `Promise<Result<T>>` から Effect (`Effect.Effect<T, GoogleMapsApiError>`) にリファクタリング

## Changes

### モバイルスクロール修正
- `UnifiedSearchResultsScreen/index.tsx`: sticky ヘッダーに `max-h-dvh overflow-y-auto overscroll-contain` を追加

### 検索結果数の改善
- `worker/src/services/google-maps.ts`: `next_page_token` を使った自動ページネーション（最大3ページ/60件）を実装

### Worker側 Effect化
- `worker/src/errors.ts`: `GoogleMapsApiError` (`Data.TaggedError`) を新規作成
- `worker/src/services/google-maps.ts`: 全関数を Effect 化、`fetchGoogleApi`/`validateStatus` 共通ヘルパー導入
- `worker/src/routes/restaurants.ts`: `Effect.all` による並列キーワード検索
- `worker/src/routes/stations.ts`: `Promise.all` → `Effect.all` + `Effect.either`
- `worker/src/routes/geocode.ts`: `Effect.runPromiseExit` によるエラーハンドリング
- テストを `Effect.runPromise` / `Effect.runPromiseExit` パターンに更新

## Test plan
- [x] `npm run lint:quick` — 0 errors
- [x] `npm run format:check` — all files formatted
- [x] `npm run typecheck` — no errors
- [x] `npm run test` — 70 tests passed (ページネーションテスト含む)
- [ ] モバイル実機で検索条件パネルのスクロール動作を確認
- [ ] 検索結果数が以前より増えていることを確認

https://claude.ai/code/session_01WMV3rfZP3jHnCjWeVXGyU2